### PR TITLE
feat: add GitHub Actions workflow for PR previews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # WebSocket Configuration
-VITE_WS_URL=ws://localhost:8080           # WebSocket server URL
-VITE_WS_PUBLIC_PATH=/ws                   # Public WebSocket endpoint path
-VITE_WS_PROTECTED_PATH=/protected/ws      # Protected WebSocket endpoint path
+RSBUILD_WS_URL=wss://options-trading-api.deriv.ai         # WebSocket server URL
+RSBUILD_WS_PUBLIC_PATH=/ws                   # Public WebSocket endpoint path
+RSBUILD_WS_PROTECTED_PATH=/ws      # Protected WebSocket endpoint path
 
 # REST API Configuration
-VITE_REST_URL=http://localhost:8080       # REST API server URL
+RSBUILD_REST_URL=https://options-trading-api.deriv.ai      # REST API server URL

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,26 @@
+name: Build Project
+description: Build the project with environment variables
+inputs:
+  RSBUILD_WS_URL:
+    description: WebSocket server URL
+    required: true
+  RSBUILD_WS_PUBLIC_PATH:
+    description: Public WebSocket endpoint path
+    required: true
+  RSBUILD_WS_PROTECTED_PATH:
+    description: Protected WebSocket endpoint path
+    required: true
+  RSBUILD_REST_URL:
+    description: REST API server URL
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Build project
+      shell: bash
+      env:
+        RSBUILD_WS_URL: ${{ inputs.RSBUILD_WS_URL }}
+        RSBUILD_WS_PUBLIC_PATH: ${{ inputs.RSBUILD_WS_PUBLIC_PATH }}
+        RSBUILD_WS_PROTECTED_PATH: ${{ inputs.RSBUILD_WS_PROTECTED_PATH }}
+        RSBUILD_REST_URL: ${{ inputs.RSBUILD_REST_URL }}
+      run: npm run build

--- a/.github/actions/npm_install_from_cache/action.yml
+++ b/.github/actions/npm_install_from_cache/action.yml
@@ -1,0 +1,8 @@
+name: Install NPM Dependencies
+description: Install npm packages with caching
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: npm ci

--- a/.github/actions/publish_to_pages/action.yml
+++ b/.github/actions/publish_to_pages/action.yml
@@ -22,7 +22,7 @@ runs:
         CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
         CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
       run: |
-        npm i wrangler@3
+        npm i wrangler@3.22.3
         cd dist
         npx wrangler pages deploy . --project-name=${{ inputs.PROJECT_NAME }} --branch=${{ inputs.CF_BRANCH }}
         echo "Preview URL: https://${{ inputs.CF_BRANCH }}.${{ inputs.PROJECT_NAME }}.pages.dev"

--- a/.github/actions/publish_to_pages/action.yml
+++ b/.github/actions/publish_to_pages/action.yml
@@ -1,0 +1,28 @@
+name: Publish to Cloudflare Pages
+description: Deploys the build to Cloudflare Pages
+inputs:
+  CLOUDFLARE_ACCOUNT_ID:
+    description: Cloudflare account ID
+    required: true
+  CLOUDFLARE_API_TOKEN:
+    description: Cloudflare API token
+    required: true
+  CF_BRANCH:
+    description: Branch name for deployment
+    required: true
+  PROJECT_NAME:
+    description: Cloudflare Pages project name
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Deploy to Cloudflare Pages
+      shell: bash
+      env:
+        CLOUDFLARE_ACCOUNT_ID: ${{ inputs.CLOUDFLARE_ACCOUNT_ID }}
+        CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}
+      run: |
+        npm i wrangler@3
+        cd dist
+        npx wrangler pages deploy . --project-name=${{ inputs.PROJECT_NAME }} --branch=${{ inputs.CF_BRANCH }}
+        echo "Preview URL: https://${{ inputs.CF_BRANCH }}.${{ inputs.PROJECT_NAME }}.pages.dev"

--- a/.github/actions/setup_node/action.yml
+++ b/.github/actions/setup_node/action.yml
@@ -1,0 +1,10 @@
+name: Setup Node
+description: Sets up Node.js environment
+runs:
+  using: composite
+  steps:
+    - name: Use Node.js 18.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.x
+        cache: 'npm'

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -1,0 +1,40 @@
+name: PR Test Deployment
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  NODE_ENV: development
+
+jobs:
+  build_and_preview:
+    name: Build and Deploy Preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: ./.github/actions/setup_node
+
+      - name: Install dependencies
+        uses: ./.github/actions/npm_install_from_cache
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          RSBUILD_WS_URL: ${{ secrets.RSBUILD_WS_URL }}
+          RSBUILD_WS_PUBLIC_PATH: ${{ secrets.RSBUILD_WS_PUBLIC_PATH }}
+          RSBUILD_WS_PROTECTED_PATH: ${{ secrets.RSBUILD_WS_PROTECTED_PATH }}
+          RSBUILD_REST_URL: ${{ secrets.RSBUILD_REST_URL }}
+
+      - name: Publish to Cloudflare Pages
+        uses: ./.github/actions/publish_to_pages
+        with:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_BRANCH: pr-${{ github.event.pull_request.number }}
+          PROJECT_NAME: champion-trader

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,2 @@
 export { apiClient } from './api/axios_interceptor';
 export * from './api/websocket/types';
-export { tradeService } from './endpoints/trade';
-export { marketService } from './endpoints/market';


### PR DESCRIPTION
This PR adds GitHub Actions workflow to automatically:
- Run tests for each PR
- Build the project
- Deploy to Cloudflare Pages
- Generate unique preview URLs

Required Setup:
The following secrets need to be added to the repository:
- RSBUILD_WS_URL
- RSBUILD_WS_PUBLIC_PATH
- RSBUILD_WS_PROTECTED_PATH
- RSBUILD_REST_URL
- CLOUDFLARE_ACCOUNT_ID
- CLOUDFLARE_API_TOKEN

## Summary by Sourcery

Set up a GitHub Actions workflow to run tests, build the project, and deploy it to Cloudflare Pages for each pull request. This workflow generates preview URLs for each PR.

CI:
- Add a GitHub Actions workflow to automate testing, building, and deploying previews for pull requests.

Deployment:
- Deploy previews to Cloudflare Pages for each pull request.