### PR TITLE
fix: fix staging workflow

### DIFF
--- a/.github/actions/publish_to_staging/action.yml
+++ b/.github/actions/publish_to_staging/action.yml
@@ -21,5 +21,5 @@ runs:
       run: |
         npm i wrangler@3.22.3
         cd dist
-        npx wrangler pages deploy . --project-name=${{ inputs.PROJECT_NAME }} --production
+        npx wrangler pages deploy . --project-name=${{ inputs.PROJECT_NAME }}
         echo "Staging URL: https://${{ inputs.PROJECT_NAME }}.pages.dev"


### PR DESCRIPTION
This pull request includes a minor change to the `.github/actions/publish_to_staging/action.yml` file. The change removes the `--production` flag from the `wrangler pages deploy` command to ensure the deployment is specifically for staging.

* [`.github/actions/publish_to_staging/action.yml`](diffhunk://#diff-64a724ee0003bd4900f0a2045ef91e3ef0aa28c0ce92b01d255fc1f36d013caeL24-R24): Removed the `--production` flag from the `wrangler pages deploy` command to deploy to staging.

## Summary by Sourcery

CI:
- Removed the `--production` flag from the `wrangler pages deploy` command in the staging workflow.