### PR TITLE
fix: fix staging workflow

### DIFF
--- a/.github/actions/publish_to_staging/action.yml
+++ b/.github/actions/publish_to_staging/action.yml
@@ -22,4 +22,4 @@ runs:
         npm i wrangler@3.22.3
         cd dist
         npx wrangler pages deploy . --project-name=${{ inputs.PROJECT_NAME }}
-        echo "Staging URL: https://${{ inputs.PROJECT_NAME }}.pages.dev"
+        echo "Staging URL: https://staging.${{ inputs.PROJECT_NAME }}.pages.dev"


### PR DESCRIPTION
This pull request includes a change to the `.github/actions/publish_to_staging/action.yml` file to update the URL format for staging deployments.

* Updated the staging URL format to include the `staging` subdomain in the `echo` command. (`[.github/actions/publish_to_staging/action.ymlL25-R25](diffhunk://#diff-64a724ee0003bd4900f0a2045ef91e3ef0aa28c0ce92b01d255fc1f36d013caeL25-R25)`)

## Summary by Sourcery

CI:
- Update the staging URL format in the publish to staging workflow.