### PR TITLE
chore: responsive height adjustment in real device

### DIFF
--- a/src/layouts/MainLayout/MainLayout.tsx
+++ b/src/layouts/MainLayout/MainLayout.tsx
@@ -12,11 +12,11 @@ export const MainLayout: React.FC<MainLayoutProps> = ({ children }) => {
   const { isLoggedIn } = useClientStore();
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-[100dvh] h-[100dvh]">
       <SideNav />
-      <div className="flex flex-col flex-1 relative">
+      <div className="flex flex-col flex-1 relative overflow-hidden">
         <Header className="sticky top-0 z-50" />
-        <main className="flex-1 flex flex-col overflow-y-auto">
+        <main className="flex-1 flex flex-col overflow-y-auto overflow-x-hidden">
           {children}
         </main>
         {isLoggedIn && <Footer className="sticky bottom-0 z-50" />}

--- a/src/layouts/MainLayout/__tests__/MainLayout.test.tsx
+++ b/src/layouts/MainLayout/__tests__/MainLayout.test.tsx
@@ -36,7 +36,6 @@ describe('MainLayout', () => {
     );
     // Check for base layout classes.
     expect(container.firstChild).toHaveClass('flex');
-    expect(container.firstChild).toHaveClass('min-h-screen');
   });
 
   it('does not render footer when user is logged out', () => {

--- a/src/screens/TradePage/TradePage.tsx
+++ b/src/screens/TradePage/TradePage.tsx
@@ -36,7 +36,7 @@ export const TradePage: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col flex-1 landscape:flex-row landscape:h-[100dvh] landscape:relative">
+    <div className="flex flex-col flex-1 landscape:flex-row landscape:h-[100dvh] h-[100dvh] landscape:relative">
       <div
         className="hidden landscape:block landscape:absolute landscape:top-0 landscape:left-0 landscape:right-0 landscape:bg-white landscape:z-10 border-b border-opacity-10"
         id="instrument-tab-bar"
@@ -65,7 +65,7 @@ export const TradePage: React.FC = () => {
           </div>
         </div>
 
-        <div className="flex flex-col flex-1 landscape:mt-[72px] h-[calc(100vh-200px)] landscape:h-[calc(100vh-72px)]">
+        <div className="flex flex-col flex-1 landscape:mt-[72px] h-[calc(100dvh-200px)] landscape:h-[calc(100dvh-72px)]">
           <Suspense fallback={<div>Loading...</div>}>
             <Chart className="flex-1" />
           </Suspense>


### PR DESCRIPTION
This pull request includes several changes to improve the layout and responsiveness of the `MainLayout` and `TradePage` components. The most important changes involve updating the height properties to use the `100dvh` unit for better handling of viewport height on mobile devices and ensuring consistent overflow behavior.

Changes to `MainLayout`:

* Updated the `div` container to use `min-h-[100dvh] h-[100dvh]` instead of `min-h-screen` for better viewport height handling on mobile devices. (`src/layouts/MainLayout/MainLayout.tsx`)
* Added `overflow-hidden` to the `div` container and `overflow-x-hidden` to the `main` element to prevent horizontal overflow. (`src/layouts/MainLayout/MainLayout.tsx`)
* Removed the test case checking for the `min-h-screen` class. (`src/layouts/MainLayout/__tests__/MainLayout.test.tsx`)

Changes to `TradePage`:

* Updated the `div` container to use `h-[100dvh]` for consistent viewport height handling. (`src/screens/TradePage/TradePage.tsx`)
* Modified the height calculation for the `div` container to use `100dvh` instead of `100vh` for better responsiveness. (`src/screens/TradePage/TradePage.tsx`)

## Summary by Sourcery

Update layout height and overflow behavior for improved responsiveness on mobile devices.

Enhancements:
- Use `100dvh` instead of `100vh` or `min-h-screen` for better handling of viewport height on mobile devices.
- Prevent horizontal overflow by adding `overflow-hidden` to the main container and `overflow-x-hidden` to the content area.

Tests:
- Remove test case checking for the `min-h-screen` class.