### PR TITLE
Farabi/add server time

### DIFF
--- a/src/components/ServerTime/ServerTime.tsx
+++ b/src/components/ServerTime/ServerTime.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from "react";
+import { useServerTimeStore } from "@/stores/serverTimeStore";
+
+export const ServerTime: React.FC = () => {
+  const { serverTime, setServerTime } = useServerTimeStore();
+
+  useEffect(() => {
+    const updateTime = () => {
+      setServerTime(new Date());
+    };
+
+    // Update immediately and then every second
+    updateTime();
+    const interval = setInterval(updateTime, 1000);
+
+    return () => clearInterval(interval);
+  }, [setServerTime]);
+
+  return (
+    <div className="text-xs text-gray-700 flex justify-between items-center py-2 px-2">
+      <div>
+        {serverTime.getDate().toString().padStart(2, '0')} {' '}
+        {serverTime.toLocaleString('default', { month: 'short' })} {' '}
+        {serverTime.getFullYear()}
+      </div>
+      <div>
+        {serverTime.toTimeString().split(' ')[0]} GMT
+      </div>
+    </div>
+  );
+};

--- a/src/components/ServerTime/index.ts
+++ b/src/components/ServerTime/index.ts
@@ -1,0 +1,1 @@
+export { ServerTime } from "./ServerTime";

--- a/src/screens/ContractDetailsPage/ContractDetailsPage.tsx
+++ b/src/screens/ContractDetailsPage/ContractDetailsPage.tsx
@@ -43,10 +43,10 @@ const MobileContractDetailsPage: React.FC = () => {
 
         {/* Close Button */}
         <div className="fixed bottom-0 left-0 right-0 z-[60]">
-          <div className="mx-2 text-center">
+          <div className="mx-2 mb-2 text-center">
             <button
               onClick={() => navigate(-1)}
-              className="text-white bg-black max-w-[500px] mx-auto  w-full p-3 px-8 text-center rounded-xl shadow-md"
+              className="text-white bg-black max-w-[500px] mx-auto w-full p-3 px-8 text-center rounded-xl shadow-md"
             >
               Close
             </button>

--- a/src/screens/TradePage/TradePage.tsx
+++ b/src/screens/TradePage/TradePage.tsx
@@ -35,7 +35,7 @@ export const TradePage: React.FC = () => {
     <div
       className={`flex ${
         isLandscape ? "flex-row relative" : "flex-col"
-      } flex-1 h-[100dvh]`}
+      } flex-1 h-[100%]`}
       data-testid="trade-page"
     >
       <div
@@ -68,9 +68,11 @@ export const TradePage: React.FC = () => {
             </Suspense>
           </div>
 
-          <Suspense fallback={<div>Loading...</div>}>
-            <DurationOptions />
-          </Suspense>
+          {!isLandscape && (
+            <Suspense fallback={<div>Loading...</div>}>
+              <DurationOptions />
+            </Suspense>
+          )}
         </div>
       </div>
 

--- a/src/screens/TradePage/__tests__/TradePage.test.tsx
+++ b/src/screens/TradePage/__tests__/TradePage.test.tsx
@@ -168,7 +168,7 @@ describe('TradePage', () => {
     expect(tradePage.className).toContain('flex');
     expect(tradePage.className).toContain('flex-col');
     expect(tradePage.className).toContain('flex-1');
-    expect(tradePage.className).toContain('h-[100dvh]');
+    expect(tradePage.className).toContain('h-[100%]');
   });
 
   it('renders in landscape mode', async () => {
@@ -185,7 +185,6 @@ describe('TradePage', () => {
 
     // Balance display should be visible in landscape mode
     expect(screen.getByTestId('bottom-sheet')).toBeInTheDocument();
-    expect(screen.getByTestId('duration-options')).toBeInTheDocument();
     expect(screen.getByTestId('market-selector')).toBeInTheDocument();
 
     // // Check for MarketInfo with selected market
@@ -197,7 +196,7 @@ describe('TradePage', () => {
     expect(tradePage.className).toContain('flex-row');
     expect(tradePage.className).toContain('relative');
     expect(tradePage.className).toContain('flex-1');
-    expect(tradePage.className).toContain('h-[100dvh]');
+    expect(tradePage.className).toContain('h-[100%]');
   });
 
   it('shows "Select Market" when no market is selected', () => {

--- a/src/screens/TradePage/components/TradeFormController.tsx
+++ b/src/screens/TradePage/components/TradeFormController.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense, lazy, useEffect, useState } from "react"
+import { ServerTime } from "@/components/ServerTime"
 import { TradeButton } from "@/components/TradeButton"
 import { ResponsiveTradeParamLayout } from "@/components/ui/responsive-trade-param-layout"
 import { MobileTradeFieldCard } from "@/components/ui/mobile-trade-field-card"
@@ -199,7 +200,7 @@ export const TradeFormController: React.FC<TradeFormControllerProps> = ({
       </div>
       {isLandscape ? (
         // Desktop layout
-        <div className="flex-1">
+        <div className="flex-1 flex flex-col">
           <div
             className="flex flex-col gap-0"
             onMouseDown={() => {
@@ -298,6 +299,9 @@ export const TradeFormController: React.FC<TradeFormControllerProps> = ({
                 />
               </Suspense>
             ))}
+          </div>
+          <div className="mt-auto">
+            <ServerTime />
           </div>
         </div>
       ) : (

--- a/src/stores/serverTimeStore.ts
+++ b/src/stores/serverTimeStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ServerTimeStore {
+  serverTime: Date;
+  setServerTime: (time: Date) => void;
+}
+
+export const useServerTimeStore = create<ServerTimeStore>((set) => ({
+  serverTime: new Date(),
+  setServerTime: (time: Date) => set({ serverTime: time }),
+}));


### PR DESCRIPTION
This pull request introduces a new `ServerTime` component and integrates it into the `TradePage`, along with several other UI and test adjustments. The most important changes include the creation of the `ServerTime` component, its integration into the `TradePage`, and adjustments to the layout and tests.

### New `ServerTime` component:

* [`src/components/ServerTime/ServerTime.tsx`](diffhunk://#diff-6381d35ee2b0331657db8c49fffee31a95cab879406c6e050558b3afc6880714R1-R31): Created the `ServerTime` component to display the current server time, updating every second.
* [`src/components/ServerTime/index.ts`](diffhunk://#diff-3402b60d8f830e60729c18f6206f45f800ec77fc782e4b8ca9aeffef32e52188R1): Exported the `ServerTime` component.
* [`src/stores/serverTimeStore.ts`](diffhunk://#diff-9ea3cbd0233f0c76132af6b2fb57189ce8552155288a5bce18546fcb3a068a81R1-R11): Added a `serverTimeStore` using `zustand` to manage the server time state.

### Integration into `TradePage`:

* [`src/screens/TradePage/components/TradeFormController.tsx`](diffhunk://#diff-0950af5548a428b98b02d27dd6c16d7eaa3f72da2da4ce9be9cde382ed07f4e0R2): Imported and integrated the `ServerTime` component into the `TradeFormController` component, displaying it in the desktop layout. [[1]](diffhunk://#diff-0950af5548a428b98b02d27dd6c16d7eaa3f72da2da4ce9be9cde382ed07f4e0R2) [[2]](diffhunk://#diff-0950af5548a428b98b02d27dd6c16d7eaa3f72da2da4ce9be9cde382ed07f4e0L202-R203) [[3]](diffhunk://#diff-0950af5548a428b98b02d27dd6c16d7eaa3f72da2da4ce9be9cde382ed07f4e0R303-R305)

### UI adjustments:

* [`src/screens/ContractDetailsPage/ContractDetailsPage.tsx`](diffhunk://#diff-75d0b4a29989ac1eb9372f267c57e003cfc24c9e86f16c7473c6eabbe0fa152eL46-R46): Adjusted the margin for the close button container.
* [`src/screens/TradePage/TradePage.tsx`](diffhunk://#diff-92ba4cbc5a106ff4e72a200d0df823ce445f8b9d50f0b93d407e6380bc577a20L38-R38): Modified the height of the `TradePage` container and conditionally rendered the `DurationOptions` component based on the layout. [[1]](diffhunk://#diff-92ba4cbc5a106ff4e72a200d0df823ce445f8b9d50f0b93d407e6380bc577a20L38-R38) [[2]](diffhunk://#diff-92ba4cbc5a106ff4e72a200d0df823ce445f8b9d50f0b93d407e6380bc577a20R71-R75)

### Test adjustments:

* [`src/screens/TradePage/__tests__/TradePage.test.tsx`](diffhunk://#diff-9a08429d359f1f464cc0cd3a9414bb58ce56e14965a6fd7690cff67df8e0cbbaL171-R171): Updated tests to reflect the changes in the `TradePage` container height and conditional rendering of the `DurationOptions` component. [[1]](diffhunk://#diff-9a08429d359f1f464cc0cd3a9414bb58ce56e14965a6fd7690cff67df8e0cbbaL171-R171) [[2]](diffhunk://#diff-9a08429d359f1f464cc0cd3a9414bb58ce56e14965a6fd7690cff67df8e0cbbaL188) [[3]](diffhunk://#diff-9a08429d359f1f464cc0cd3a9414bb58ce56e14965a6fd7690cff67df8e0cbbaL200-R199)

## Summary by Sourcery

This pull request introduces a new `ServerTime` component to display the current server time, integrates it into the `TradePage`, and includes UI and test adjustments.

New Features:
- Introduces a `ServerTime` component that displays the current server time, updating every second.
- Adds a `serverTimeStore` using `zustand` to manage the server time state.

Enhancements:
- Integrates the `ServerTime` component into the `TradePage` for desktop layout, displaying the current server time.
- Modifies the height of the `TradePage` container to `100%`.
- Conditionally renders the `DurationOptions` component based on the layout.

Tests:
- Updates tests to reflect the changes in the `TradePage` container height and conditional rendering of the `DurationOptions` component.