### PR TITLE
fix: TradeButton title font weight to semibold

### DIFF
--- a/src/components/TradeButton/TradeButton.tsx
+++ b/src/components/TradeButton/TradeButton.tsx
@@ -55,7 +55,7 @@ export const TradeButton: React.FC<TradeButtonProps> = ({
                             <div className="flex items-center gap-2">
                                 <span
                                     className={cn(
-                                        "font-bold",
+                                        "font-semibold",
                                         isLandscape ? "text-base" : "text-lg"
                                     )}
                                 >

--- a/src/components/TradeButton/__tests__/TradeButton.test.tsx
+++ b/src/components/TradeButton/__tests__/TradeButton.test.tsx
@@ -73,7 +73,7 @@ describe("TradeButton", () => {
         const label = screen.getByText("Payout");
         const value = screen.getByText("19.55 USD");
 
-        expect(title).toHaveClass("font-bold");
+        expect(title).toHaveClass("font-semibold");
         expect(label).toHaveClass("text-[12px]");
         expect(value).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update test case to reflect the change in font weight to semibold.