### PR TITLE
Farabi/fix position filter dropdown

### DIFF
--- a/src/components/PositionComponents/PositionEmptyState.tsx
+++ b/src/components/PositionComponents/PositionEmptyState.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from "react";
-import { Briefcase } from "lucide-react";
+import { StandaloneBriefcaseFillIcon } from "@deriv/quill-icons";
 
 interface PositionEmptyStateProps {
     icon?: ReactNode;
@@ -8,7 +8,7 @@ interface PositionEmptyStateProps {
 }
 
 export const PositionEmptyState: React.FC<PositionEmptyStateProps> = ({
-    icon = <Briefcase size={64} strokeWidth={1.5} />,
+    icon = <StandaloneBriefcaseFillIcon fill="#0000003D" iconSize="2xl" />,
     positionType,
     className = "flex items-center justify-center",
 }) => {

--- a/src/components/Sidebar/positions/components/FilterDropdown.tsx
+++ b/src/components/Sidebar/positions/components/FilterDropdown.tsx
@@ -41,7 +41,7 @@ export const FilterDropdown: FC<FilterDropdownProps> = ({
             onMouseDown={(event) => event.stopPropagation()}
         >
             <button
-                className="text-sm h-9 w-full p-2 border border-theme rounded-full text-theme-muted flex items-center justify-between"
+                className="text-sm h-9 w-full p-2 bg-theme border border-theme rounded-full text-theme-muted flex items-center justify-between"
                 onClick={() => setDropdownOpen(!dropdownOpen)}
             >
                 <span>{selectedFilter}</span>

--- a/src/components/Sidebar/positions/components/PositionsPanel.tsx
+++ b/src/components/Sidebar/positions/components/PositionsPanel.tsx
@@ -73,13 +73,16 @@ export const PositionsPanel: FC = () => {
                         Closed
                     </button>
                 </div>
-                <div className="mx-4">
-                    <FilterDropdown
-                        isOpenTab={isOpenTab}
-                        selectedFilter={selectedFilter}
-                        onFilterSelect={handleFilterSelect}
-                    />
-                </div>
+                {/* Filter Dropdown - Only show when there are positions */}
+                {!positionsLoading && !positionsError && currentPositions.length > 0 && (
+                    <div className="mx-4">
+                        <FilterDropdown
+                            isOpenTab={isOpenTab}
+                            selectedFilter={selectedFilter}
+                            onFilterSelect={handleFilterSelect}
+                        />
+                    </div>
+                )}
 
                 {/* Loading State */}
                 {positionsLoading && (

--- a/src/components/Sidebar/positions/components/PositionsPanel.tsx
+++ b/src/components/Sidebar/positions/components/PositionsPanel.tsx
@@ -25,12 +25,20 @@ export const PositionsPanel: FC = () => {
     // Get current positions based on active tab
     const currentPositions = isOpenTab ? openPositions : closedPositions;
 
-    // Filter logic (simplified for now)
-    const [selectedFilter, setSelectedFilter] = useState<string>("Trade types");
+    // Filter logic with separate states for open and closed positions
+    const [openPositionsFilter, setOpenPositionsFilter] = useState<string>("Trade types");
+    const [closedPositionsFilter, setClosedPositionsFilter] = useState<string>("All time");
     const [closingContracts, setClosingContracts] = useState<Record<string, boolean>>({});
 
+    // Get the current filter based on active tab
+    const selectedFilter = isOpenTab ? openPositionsFilter : closedPositionsFilter;
+
     const handleFilterSelect = (filter: string) => {
-        setSelectedFilter(filter);
+        if (isOpenTab) {
+            setOpenPositionsFilter(filter);
+        } else {
+            setClosedPositionsFilter(filter);
+        }
         // Filter implementation would go here
     };
 

--- a/src/components/Sidebar/positions/components/PositionsPanel.tsx
+++ b/src/components/Sidebar/positions/components/PositionsPanel.tsx
@@ -12,6 +12,7 @@ import {
     PositionProfitLoss,
 } from "@/components/PositionComponents";
 import { useTradeActions } from "@/hooks";
+import { usePositionsFilter } from "@/hooks/usePositionsFilter";
 
 export const PositionsPanel: FC = () => {
     const [isOpenTab, setIsOpenTab] = useState(true);
@@ -25,22 +26,10 @@ export const PositionsPanel: FC = () => {
     // Get current positions based on active tab
     const currentPositions = isOpenTab ? openPositions : closedPositions;
 
-    // Filter logic with separate states for open and closed positions
-    const [openPositionsFilter, setOpenPositionsFilter] = useState<string>("Trade types");
-    const [closedPositionsFilter, setClosedPositionsFilter] = useState<string>("All time");
+    // Use the positions filter hook
+    const { selectedFilter, handleFilterSelect } = usePositionsFilter(isOpenTab);
+
     const [closingContracts, setClosingContracts] = useState<Record<string, boolean>>({});
-
-    // Get the current filter based on active tab
-    const selectedFilter = isOpenTab ? openPositionsFilter : closedPositionsFilter;
-
-    const handleFilterSelect = (filter: string) => {
-        if (isOpenTab) {
-            setOpenPositionsFilter(filter);
-        } else {
-            setClosedPositionsFilter(filter);
-        }
-        // Filter implementation would go here
-    };
 
     const { sell_contract } = useTradeActions();
 

--- a/src/hooks/usePositionsFilter.ts
+++ b/src/hooks/usePositionsFilter.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+/**
+ * Custom hook to manage position filter state and logic
+ * @param isOpenTab Boolean indicating if the open positions tab is active
+ * @returns Object containing the selected filter and handler function
+ */
+export function usePositionsFilter(isOpenTab: boolean) {
+    const [openPositionsFilter, setOpenPositionsFilter] = useState<string>("Trade types");
+    const [closedPositionsFilter, setClosedPositionsFilter] = useState<string>("All time");
+
+    // Get the current filter based on active tab
+    const selectedFilter = isOpenTab ? openPositionsFilter : closedPositionsFilter;
+
+    const handleFilterSelect = (filter: string) => {
+        if (isOpenTab) {
+            setOpenPositionsFilter(filter);
+        } else {
+            setClosedPositionsFilter(filter);
+        }
+        // Filter implementation would go here
+    };
+
+    return {
+        selectedFilter,
+        handleFilterSelect,
+    };
+}

--- a/src/screens/PositionsPage/PositionsPage.tsx
+++ b/src/screens/PositionsPage/PositionsPage.tsx
@@ -105,14 +105,16 @@ const PositionsPage: React.FC = () => {
                 </button>
             </div>
 
-            {/* Filter Dropdown */}
-            <div className="px-4 py-3 bg-theme-secondary">
-                <FilterDropdown
-                    isOpenTab={activeTab === "open"}
-                    selectedFilter={selectedFilter}
-                    onFilterSelect={handleFilterSelect}
-                />
-            </div>
+            {/* Filter Dropdown - Only show when there are positions */}
+            {!positionsLoading && !positionsError && currentPositions.length > 0 && (
+                <div className="px-4 py-3 bg-theme-secondary">
+                    <FilterDropdown
+                        isOpenTab={activeTab === "open"}
+                        selectedFilter={selectedFilter}
+                        onFilterSelect={handleFilterSelect}
+                    />
+                </div>
+            )}
 
             {/* Total Profit/Loss - Only show when in open tab AND there are open positions */}
             {activeTab === "open" && openPositions.length > 0 && (

--- a/src/screens/PositionsPage/PositionsPage.tsx
+++ b/src/screens/PositionsPage/PositionsPage.tsx
@@ -10,10 +10,8 @@ import {
     PositionMapper,
     PositionProfitLoss,
 } from "@/components/PositionComponents";
-import { useToastStore } from "@/stores/toastStore";
-import { TradeNotification } from "@/components/ui/trade-notification";
-import { useOrientationStore } from "@/stores/orientationStore";
-import { StandaloneFlagCheckeredFillIcon } from "@deriv/quill-icons";
+import { FilterDropdown } from "@/components/Sidebar/positions/components/FilterDropdown";
+import { usePositionsFilter } from "@/hooks/usePositionsFilter";
 
 const PositionsPage: React.FC = () => {
     const navigate = useNavigate();
@@ -21,13 +19,15 @@ const PositionsPage: React.FC = () => {
     const [swipedCard, setSwipedCard] = useState<string | null>(null);
     const [closingContracts, setClosingContracts] = useState<Record<string, boolean>>({});
 
+    // Use the positions filter hook
+    const { selectedFilter, handleFilterSelect } = usePositionsFilter(activeTab === "open");
+
     // Get positions data using the centralized hook
     const { openPositions, closedPositions, positionsLoading, positionsError, totalProfitLoss } =
         usePositionsData();
 
     // Get trade actions including sell_contract
     const tradeActions = useTradeActions();
-    const { isLandscape } = useOrientationStore();
 
     // Handle closing a contract
     const handleCloseContract = async (contractId: string) => {
@@ -103,6 +103,15 @@ const PositionsPage: React.FC = () => {
                 >
                     Closed
                 </button>
+            </div>
+
+            {/* Filter Dropdown */}
+            <div className="px-4 py-3 bg-theme-secondary">
+                <FilterDropdown
+                    isOpenTab={activeTab === "open"}
+                    selectedFilter={selectedFilter}
+                    onFilterSelect={handleFilterSelect}
+                />
             </div>
 
             {/* Total Profit/Loss - Only show when in open tab AND there are open positions */}


### PR DESCRIPTION
This pull request includes changes to the `PositionEmptyState` and `PositionsPanel` components to improve their functionality and appearance. The most important changes include updating the icon used in the `PositionEmptyState` component and refining the filter logic in the `PositionsPanel` component.

Icon update in `PositionEmptyState`:

* [`src/components/PositionComponents/PositionEmptyState.tsx`](diffhunk://#diff-aed63fe45eb11380295b2eea693e2205733288a257ce908b29b828cd7f6b3fc7L2-R2): Replaced the `Briefcase` icon from `lucide-react` with the `StandaloneBriefcaseFillIcon` from `@deriv/quill-icons` for a more consistent look. [[1]](diffhunk://#diff-aed63fe45eb11380295b2eea693e2205733288a257ce908b29b828cd7f6b3fc7L2-R2) [[2]](diffhunk://#diff-aed63fe45eb11380295b2eea693e2205733288a257ce908b29b828cd7f6b3fc7L11-R11)

Filter logic improvements in `PositionsPanel`:

* [`src/components/Sidebar/positions/components/PositionsPanel.tsx`](diffhunk://#diff-6710b9815b5229fb5fe6ff31244435d51ce8a754bfd29d900a33d40262b38e54L28-R41): Refined the filter logic by introducing separate states for open and closed positions filters, and updated the filter selection handling to accommodate these new states.

## Summary by Sourcery

Improves the Positions Panel by refining the filter logic and updating the icon used in the PositionEmptyState component for a more consistent look.

Enhancements:
- Refines the filter logic in the PositionsPanel component by introducing separate states for open and closed positions filters, and updates the filter selection handling to accommodate these new states.
- Replaces the Briefcase icon in the PositionEmptyState component with the StandaloneBriefcaseFillIcon for a more consistent look.